### PR TITLE
Fix working-directory for reports

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: PHPUnit
       working-directory: ${{ inputs.working-directory }}
       shell: bash
-      run: ./vendor/bin/phpunit --coverage-clover ${{ inputs.working-directory }}/reports/${{ inputs.coverage-report-name }}  --log-junit ${{ inputs.working-directory }}/reports/${{ inputs.report-name }} ${{ inputs.extra-args }}
+      run: ./vendor/bin/phpunit --coverage-clover ./reports/${{ inputs.coverage-report-name }}  --log-junit ./reports/${{ inputs.report-name }} ${{ inputs.extra-args }}
 
     - name: Upload report
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
À cause du path relatif les rapport se génère pas au bon endroit

Testé ici : https://github.com/kronostechnologies/billing/actions/runs/12168000241